### PR TITLE
send the sigint to the wrapped launch file to not only stop the wrapper

### DIFF
--- a/launch/start_experiment.launch.py
+++ b/launch/start_experiment.launch.py
@@ -1,6 +1,3 @@
-import os
-
-from ament_index_python import get_package_share_directory
 from launch import LaunchDescription
 from launch_ros.actions import Node
 from launch.substitutions import LaunchConfiguration
@@ -24,7 +21,10 @@ def generate_launch_description():
         executable='lifecycle_launch_node',
         name='wpf_launch_lifecycle_node',
         output='screen',
-        parameters=[{'use_sim_time' : True},
+        emulate_tty=True,
+        parameters=[{'use_sim_time' : True,
+                     'autostart': True,
+                    },
                     config_filepath],
     )
 
@@ -35,23 +35,11 @@ def generate_launch_description():
         parameters=[config_filepath],
     )
 
-    # Autostart experiment
-    lifecycle_manager = Node(
-        package='nav2_lifecycle_manager',
-        executable='lifecycle_manager',
-        name='lifecycle_manager_autostart',
-        output='screen',
-        parameters=[{'autostart': True,
-                     'bond_timeout': 0.0, # python lifecycle node -> disable bond check
-                     'node_names': ['wpf_launch_lifecycle_node']}],
-    )
-
 
     ld = LaunchDescription()
     ld.add_action(log_decision_module_state)
     ld.add_action(decl_config_filepath)
     ld.add_action(start_experiment)
     ld.add_action(restart_experiment_manager)
-    ld.add_action(lifecycle_manager)
 
     return ld


### PR DESCRIPTION
This makes sure to send the sigint from ctrl + c instead of just stopping the wrapper.